### PR TITLE
Fixed a typo in Bootstrap3 renderer

### DIFF
--- a/src/Fuel/Fieldset/Render/Bootstrap3.php
+++ b/src/Fuel/Fieldset/Render/Bootstrap3.php
@@ -73,7 +73,7 @@ class Bootstrap3 extends Render
 
 		if ($renderGroup)
 		{
-			$content .= '<div>';
+			$content .= '</div>';
 		}
 
 		return $content;


### PR DESCRIPTION
Fixes generating of unclosed div when rendering a render group (i.e. form).
