### PR TITLE
Update Bootstrap3.php

### DIFF
--- a/src/Render/Bootstrap3.php
+++ b/src/Render/Bootstrap3.php
@@ -66,7 +66,7 @@ class Bootstrap3 extends Render
 		
 		if (trim($element->getLabel()) != '')
 		{
-			$content .= '<label for="'.$element->getAttribute('id').'">'.$element->getLabel().'</label>';
+			$content .= '<label for="'.$element->getAttribute('id').'">'.$element->getValue().'</label>';
 		}
 		
 		$content .= $elementHtml;


### PR DESCRIPTION
In Bootstrap3 Form Labels are named with the Value and not the Label itself.
Label is used for the "for=" in the label and "id=" in input field.
Value is used as the Label Name and then as "placeholder" attribute in input field.
Perhaps this can be both changed?
