### PR TITLE
Add renderElement() and getElementLabel() in Form

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -23,6 +23,19 @@ class Form extends InputContainer
 {
 
 	/**
+	 * @var Render
+	 */
+	protected $renderer;
+	
+	/**
+	 * @param Render $renderer
+	 */
+	public function setRenderer(Render $renderer)
+	{
+		$this->renderer = $renderer;
+	}
+
+	/**
 	 * Should return a html string that represents the rendered object
 	 *
 	 * @param Render $renderer
@@ -31,8 +44,10 @@ class Form extends InputContainer
 	 *
 	 * @since 2.0
 	 */
-	public function render(Render $renderer)
+	public function render(Render $renderer = null)
 	{
+		$renderer = $renderer ?: $this->renderer;
+
 		$elements = '';
 
 		foreach ( $this->getContents() as $element )
@@ -43,4 +58,25 @@ class Form extends InputContainer
 		return Html::tag('form', $this->getAttributes(), $elements);
 	}
 
+	/**
+	 * Should return a html string of one emement
+	 * 
+	 * @param string $name
+	 * @return string
+	 */
+	public function renderElement($name)
+	{
+		return $this->get($name)->render($this->renderer);
+	}
+
+	/**
+	 * Should return label text of one emement
+	 * 
+	 * @param string $name
+	 * @return string
+	 */
+	public function getElementLabel($name)
+	{
+		return $this->get($name)->getLabel();
+	}
 }

--- a/tests/unit/Fuel/Fieldset/FormTest.php
+++ b/tests/unit/Fuel/Fieldset/FormTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Fuel\Fieldset;
+
+use Fuel\Fieldset\Render\BasicRender;
+
+class FormTest extends \Codeception\TestCase\Test
+{
+	/**
+	* @var \CodeGuy
+	*/
+	protected $form;
+
+	protected function _before()
+	{
+		$this->form = new Form();
+	}
+
+	protected function _after()
+	{
+	}
+
+	public function testGetElement()
+	{
+		$this->form['input_text1'] = new Input\Text('input_text1');
+		$this->form['input_text1']->setLabel('input_text1_label');
+		$renderer = new BasicRender();
+		$this->form->setRenderer($renderer);
+		
+		$this->assertEquals('<input value="" name="input_text1" type="text"/>', $this->form->renderElement('input_text1'));
+		$this->assertEquals('input_text1_label', $this->form->getElementLabel('input_text1'));
+	}
+
+}


### PR DESCRIPTION
In some cases, we want to customize each of Form HTML more freely.
v2 has Render classes, but still want to write Form HTML as much as possible in view files.

This PR makes it possible like below:

``` php
$form = new Form;
$renderer = new BasicRender();
$form->setRenderer($renderer);

$form['name'] = new Input\Text('name');
$form['name']->setLabel('label');
```

And `$form->renderElement('name')` returns HTML of the Input\Text element.
`$form->getElementLabel('name')` returns the label text of it.

So if we pass the `$form` object to view, we can make a view like below:

``` php
<form role="form">
  <div class="form-group">
    <label for="name"><?= $form->getElementLabel('name') ?></label>
    <?= $form->renderElement('name') ?>
  </div>
...
```

In fact we also need a method to get validation error message, but I don't know how to do it.

Any comments are welcome.
